### PR TITLE
Added French keymap as "CONFIG 1,3".

### DIFF
--- a/libraries/TKeyboard/src/TKeyboard.cpp
+++ b/libraries/TKeyboard/src/TKeyboard.cpp
@@ -120,6 +120,18 @@ static const uint8_t key_ascii_de[][2] BASIC_DAT = {
   { 's', 'S'},{ 't', 'T'},{ 'u', 'U'},{ 'v', 'V'},{ 'w', 'W'},{ 'x', 'X'},{ 'z', 'Z'},{ 'y', 'Y'},
 };
 
+// French keyboard (code page 437)
+static const uint8_t key_ascii_fr[][2] BASIC_DAT = {
+  /*{0x1B,0x1B},{0x09,0x09},{0x0D,0x0D},{0x08,0x08},{0x7F,0x7F},*/
+  { ' ', ' '},{ '\x97','%'},{ 'm', 'M'},{ ';', '.'},{ ')', '\xF8'},{ ':', '/'},{ '!', '\x7F'},{ '\x7F', '\x7F'},
+  { '$', '\x9C'},{'\x7F', '\x7F'},{ '*','\xE6'},{ '=', '+'},{ '?','?'},{ '\x85', '0'},{ '&', '1'},{ '\x82', '2'},
+  { '"', '3'},{ '\'', '4'},{ '(', '5'},{ '-', '6'},{ '\x8A', '7'},{ '_', '8'},{ '\x80', '9'},{'\x7F', '\x7F'},
+  {   0,  0 },{   0,  0 },{   0,  0 },{   0,  0 },{   0,  0 },{   0,  0 },{ 'q', 'Q'},{ 'b', 'B'},
+  { 'c', 'C'},{ 'd', 'D'},{ 'e', 'E'},{ 'f', 'F'},{ 'g', 'G'},{ 'h', 'H'},{ 'i', 'I'},{ 'j', 'J'},
+  { 'k', 'K'},{ 'l', 'L'},{ ',', '?'},{ 'n', 'N'},{ 'o', 'O'},{ 'p', 'P'},{ 'a', 'A'},{ 'r', 'R'},
+  { 's', 'S'},{ 't', 'T'},{ 'u', 'U'},{ 'v', 'V'},{ 'z', 'z'},{ 'x', 'X'},{ 'y', 'Y'},{ 'w', 'W'},
+};
+
 // Conversion table for numeric pad keys 94-111
 // { Normal code, NumLock/Shift code, 1: key code  0: ASCII code }
 static const uint8_t tenkey[][3] BASIC_DAT = {
@@ -150,6 +162,7 @@ void TKeyboard::setLayout(uint8_t layout)
   case 0:	key_ascii = key_ascii_jp; break;
   case 1:	key_ascii = key_ascii_us; break;
   case 2:	key_ascii = key_ascii_de; break;
+  case 3:	key_ascii = key_ascii_fr; break;
   default:	key_ascii = key_ascii_us; break;
   }
 }
@@ -520,6 +533,22 @@ keyEvent TKeyboard::read()
     default:		c.value = 0; break;
     }
     goto DONE;
+  } else if (kbd_layout == 3 && sts_state.kevt.ALTGR && code != PS2KEY_R_Alt) {
+    switch (code) {
+    case PS2KEY_2:	c.value = '~'; break;
+    case PS2KEY_3:	c.value = '#'; break;
+    case PS2KEY_4:	c.value = '{'; break;
+    case PS2KEY_5:	c.value = '['; break;
+    case PS2KEY_6:	c.value = '|'; break;
+    case PS2KEY_7:	c.value = '`'; break;
+    case PS2KEY_8:	c.value = '\\'; break;
+    case PS2KEY_9:	c.value = '^'; break;
+    case PS2KEY_0:	c.value = '@'; break;
+    case PS2KEY_minus:	c.value = ']'; break;
+    case PS2KEY_Hat:	c.value = '}'; break;
+    default:		c.value = 0; break;
+    }
+    goto DONE;
   } else if (code >= PS2KEY_Space && code <= PS2KEY_Z) {
     // Keys affected by the state of CapsLock (A-Z)
     if (code >= PS2KEY_A && code <= PS2KEY_Z)
@@ -664,6 +693,11 @@ keyEvent TKeyboard::read()
         c.value = '\xf8';
       else
         c.value = '^';
+    } else if (kbd_layout == 3) {
+      if (sts_state.kevt.SHIFT)
+        c.value = 0;
+      else
+        c.value = '\xFD';
     }
     goto DONE;
   } else {

--- a/ttbasic/basic_config.cpp
+++ b/ttbasic/basic_config.cpp
@@ -87,8 +87,8 @@ detected; PAL60 mode is not currently implemented. +
 The semantics of this option are therefore likely to change in the future.
 
 * `1`: Keyboard layout +
-  Three different keyboard layouts are supported: +
-  `0` (Japanese), `1` (US English, default) and `2` (German).
+  Four different keyboard layouts are supported: +
+  `0` (Japanese), `1` (US English, default), `2` (German) and `3` (French).
 
 * `2`: Interlacing +
   Sets the video output to progressive (`0`) or interlaced (`1`). A change
@@ -168,8 +168,8 @@ void SMALL Basic::iconfig() {
     }
     break;
   case 1: // キーボード補正
-    if (value < 0 || value > 2)  {
-      E_VALUE(0, 2);
+    if (value < 0 || value > 3)  {
+      E_VALUE(0, 3);
     } else {
 #if !defined(HOSTED) && !defined(H3)
       kb.setLayout(value);


### PR DESCRIPTION
Hello Uli,
I attended your FOSDEM2019 talk and loved the idea, so I made 25 boards as a self-teaching experiment (well, 24 as one VS23010 is dead). I finally added French keyboard support.
I was slightly worried by the comment in SAVE CONFIG about a possibly irrecoverable situation, so I was thinking about "press shift while booting to disable loading /flash/.config" but that would require moving PS/2 init earlier than the early init function, and I am not sure what causes the keyboard to be polled or whether it is interrupt-driven. To be continued.