### PR TITLE
fixes for issues #16/#17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+build
+doc
+tools
+libraries
+ttbasic/epigrams.h
+ttbasic/funtbl.h
+ttbasic/kwenum.h
+ttbasic/kwtbl.h
+ttbasic/numfuntbl.h
+ttbasic/strfuntbl.h
+ttbasic/version.h
+

--- a/ttbasic/basic.cpp
+++ b/ttbasic/basic.cpp
@@ -3106,9 +3106,11 @@ void SMALL Basic::isavepcx() {
 
   for (;;) {
     if (*cip == I_POS) {
+      cip++;
       if (getParam(x, 0, sc0.getGWidth() - 1, I_COMMA)) return;
       if (getParam(y, 0, vs23.lastLine() - 1, I_NONE)) return;
     } else if (*cip == I_SIZE) {
+      cip++;
       if (getParam(w, 0, sc0.getGWidth() - x - 1, I_COMMA)) return;
       if (getParam(h, 0, vs23.lastLine() - y - 1, I_NONE)) return;
     } else

--- a/ttbasic/basic_video.cpp
+++ b/ttbasic/basic_video.cpp
@@ -469,27 +469,21 @@ Read a video controller register.
 @reg	video controller register number
 \ret Register contents.
 \note
-Valid register numbers are: `$01`, `$53`, `$84`, `$86`, `$9F` and `$B7`.
+Valid register numbers are: `$05`, `$53`, `$84`, `$86`, `$9F` and `$B7`.
 \ref VREG
 ***/
-static const uint8_t vs23_read_regs[] PROGMEM = {
-  0x01, 0x9f, 0x84, 0x86, 0xb7, 0x53
-};
 num_t BASIC_INT Basic::nvreg() {
 #ifdef USE_VS23
-  int32_t a = getparam();
-  bool good = false;
-  for (uint32_t i = 0; i < sizeof(vs23_read_regs); ++i) {
-    if (pgm_read_byte(&vs23_read_regs[i]) == a) {
-      good = true;
-      break;
-    }
+  uint32_t opcode = getparam();
+  switch(opcode) {
+    case 0x05:
+    case 0x84:
+    case 0x86:
+    case 0xB7: return SpiRamReadRegister8(opcode);
+    case 0x53:
+    case 0x9F: return SpiRamReadRegister(opcode);
+    default:   err = ERR_VALUE; return 0;
   }
-  if (!good) {
-    err = ERR_VALUE;
-    return 0;
-  } else
-    return SpiRamReadRegister(a);
 #else
   err = ERR_NOT_SUPPORTED;
   return 0;


### PR DESCRIPTION
- it's now possible to read the video status register (opcode 5, was 1)
- vreg() return values are now limited to their respective length