### PR TITLE
fixes for issues #16/#17/#18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+build
+doc
+tools
+libraries
+ttbasic/epigrams.h
+ttbasic/funtbl.h
+ttbasic/kwenum.h
+ttbasic/kwtbl.h
+ttbasic/numfuntbl.h
+ttbasic/strfuntbl.h
+ttbasic/version.h
+

--- a/ttbasic/BString.cpp
+++ b/ttbasic/BString.cpp
@@ -150,15 +150,13 @@ unsigned char BString::reserve(unsigned int size) {
 
 unsigned char BString::changeBuffer(unsigned int maxStrLen) {
     size_t newSize = (maxStrLen + 16) & (~0xf);
-    char *newbuffer;
+    char *newbuffer = NULL;
 #ifdef ESP8266
-    if (newSize > 262144) {
+    if (newSize <= 262144)
       // umm seems to crap out instead of reporting an error if you allocate
       // anything larger than about 9MB for some reason...
       // Weirdly enough, this does not seem to happen in variable.h, for
       // example.
-      newbuffer = NULL;
-    } else
 #endif
     newbuffer = (char *) realloc(buffer, newSize);
     if(newbuffer) {
@@ -171,7 +169,8 @@ unsigned char BString::changeBuffer(unsigned int maxStrLen) {
         buffer = newbuffer;
         return 1;
     }
-    buffer = newbuffer;
+    // realloc() failed so buffer remains
+    // untouched/valid
     return 0;
 }
 

--- a/ttbasic/basic.cpp
+++ b/ttbasic/basic.cpp
@@ -2359,6 +2359,7 @@ void SMALL Basic::irenum() {
       case I_GOTO:
       case I_GOSUB:
       case I_THEN:
+      case I_RESTORE:
 	i++;
 	if (ptr[i] == I_NUM) {		// XXX: I_HEXNUM? :)
 	  num = UNALIGNED_NUM_T(&ptr[i+1]);

--- a/ttbasic/basic.cpp
+++ b/ttbasic/basic.cpp
@@ -3106,9 +3106,11 @@ void SMALL Basic::isavepcx() {
 
   for (;;) {
     if (*cip == I_POS) {
+      cip++;
       if (getParam(x, 0, sc0.getGWidth() - 1, I_COMMA)) return;
       if (getParam(y, 0, vs23.lastLine() - 1, I_NONE)) return;
     } else if (*cip == I_SIZE) {
+      cip++;
       if (getParam(w, 0, sc0.getGWidth() - x - 1, I_COMMA)) return;
       if (getParam(h, 0, vs23.lastLine() - y - 1, I_NONE)) return;
     } else

--- a/ttbasic/basic_io.cpp
+++ b/ttbasic/basic_io.cpp
@@ -116,7 +116,7 @@ BString Basic::si2cr() {
     goto out;
   Wire.requestFrom(i2cAdr, rdlen);
   while (Wire.available()) {
-    in += Wire.read();
+    in += (char)Wire.read();
   }
 out:
   return in;

--- a/ttbasic/basic_io.cpp
+++ b/ttbasic/basic_io.cpp
@@ -10,8 +10,6 @@ void SMALL basic_init_io() {
   digitalWrite(2, LOW);
 }
 
-uint16_t pcf_state = 0xffff;
-
 /***bc io GPOUT
 Sets the state of a general-purpose I/O pin.
 \usage GPOUT pin, value
@@ -23,6 +21,7 @@ Sets the state of a general-purpose I/O pin.
 \ref GPIN()
 ***/
 void Basic::idwrite() {
+  static uint16_t pcf_state = 0xffff;
   int32_t pinno,  data;
 
   if ( getParam(pinno, 0, 15, I_COMMA) ) return;
@@ -37,15 +36,12 @@ void Basic::idwrite() {
 
   // XXX: frequency is higher when running at 160 MHz because F_CPU is wrong
   Wire.beginTransmission(0x20);
-  Wire.write(pcf_state & 0xff);
-  Wire.write(pcf_state >> 8);
+  retval[1]  = Wire.write(pcf_state & 0xff);
+  retval[1] += Wire.write(pcf_state >> 8);
 
+  retval[0] = Wire.endTransmission();
 #ifdef DEBUG_GPIO
-  int ret = 
-#endif
-  Wire.endTransmission();
-#ifdef DEBUG_GPIO
-  Serial.printf("wire st %d pcf 0x%x\n", ret, pcf_state);
+  Serial.printf("wire st %d pcf 0x%x\n", retval[0], pcf_state);
 #endif
 }
 
@@ -68,13 +64,16 @@ num_t BASIC_INT Basic::ni2cw() {
   out = istrexp();
   if (checkClose()) return 0;
 
+  // SDA is multiplexed with MVBLK0, so we wait for block move to finish
+  // to avoid interference.
+  while (!blockFinished()) {}
+
   // I2Cデータ送信
   Wire.beginTransmission(i2cAdr);
-  if (out.length()) {
-    for (uint32_t i = 0; i < out.length(); i++)
-      Wire.write(out[i]);
+  if ((retval[1] = out.length())) {
+    retval[1] = Wire.write((const uint8_t *)out.c_str(), retval[1]);
   }
-  return Wire.endTransmission();
+  return retval[0] = Wire.endTransmission();
 }
 
 /***bf io I2CR
@@ -96,29 +95,35 @@ BString Basic::si2cr() {
   int32_t i2cAdr, rdlen;
   BString in, out;
 
-  if (checkOpen()) goto out;
-  if (getParam(i2cAdr, 0, 0x7f, I_COMMA)) goto out;
-  out = istrexp();
-  if (*cip++ != I_COMMA) {
-    E_SYNTAX(I_COMMA);
-    goto out;
-  }
-  if (getParam(rdlen, 0, INT32_MAX, I_CLOSE)) goto out;
+  do {  // break target
+    if (checkOpen()) break;
+    if (getParam(i2cAdr, 0, 0x7f, I_COMMA)) break;
+    out = istrexp();
+    if (*cip++ != I_COMMA) {
+        E_SYNTAX(I_COMMA);
+        break;
+    }
+    if (getParam(rdlen, 0, INT32_MAX, I_CLOSE)) break;
 
-  // I2Cデータ送受信
-  Wire.beginTransmission(i2cAdr);
+    // SDA is multiplexed with MVBLK0, so we wait for block move to finish
+    // to avoid interference.
+    while (!blockFinished()) {}
 
-  // 送信
-  if (out.length()) {
-    Wire.write((const uint8_t *)out.c_str(), out.length());
-  }
-  if ((retval[0] = Wire.endTransmission()))
-    goto out;
-  Wire.requestFrom(i2cAdr, rdlen);
-  while (Wire.available()) {
-    in += (char)Wire.read();
-  }
-out:
+    // I2Cデータ送受信
+    Wire.beginTransmission(i2cAdr);
+
+    // 送信
+    if ((retval[1] = out.length())) {
+      retval[1] = Wire.write((const uint8_t *)out.c_str(), retval[1]);
+    }
+    if ((retval[0] = Wire.endTransmission())|| !rdlen) break;
+
+    Wire.requestFrom(i2cAdr, rdlen);
+    while (Wire.available()) {
+      in += (char)Wire.read();
+    }
+  } while (0);
+
   return in;
 }
 
@@ -181,15 +186,19 @@ num_t BASIC_INT Basic::ngpin() {
   if (checkOpen()) return 0;
   if (getParam(a, 0, 15, I_NONE)) return 0;
   if (checkClose()) return 0;
+
+  // SDA is multiplexed with MVBLK0, so we wait for block move to finish
+  // to avoid interference.
   while (!blockFinished()) {}
+
+  // no choice, we need 2 bytes
   if (Wire.requestFrom(0x20, 2) != 2) {
     err = ERR_IO;
     return 0;
-  } else {
-    uint16_t state = Wire.read();
-    state |= Wire.read() << 8;
-    return !!(state & (1 << a));
   }
+  uint16_t state = Wire.read();
+  state |= Wire.read() << 8;
+  return !!(state & (1 << a));
 }
 
 /***bf io ANA
@@ -202,8 +211,7 @@ num_t BASIC_FP Basic::nana() {
   err = ERR_NOT_SUPPORTED;
   return 0;
 #else
-  if (checkOpen()) return 0;
-  if (checkClose()) return 0;
+  if (checkOpen()||checkClose()) return 0;
   return analogRead(A0);    // 入力値取得
 #endif
 }

--- a/ttbasic/basic_video.cpp
+++ b/ttbasic/basic_video.cpp
@@ -469,27 +469,21 @@ Read a video controller register.
 @reg	video controller register number
 \ret Register contents.
 \note
-Valid register numbers are: `$01`, `$53`, `$84`, `$86`, `$9F` and `$B7`.
+Valid register numbers are: `$05`, `$53`, `$84`, `$86`, `$9F` and `$B7`.
 \ref VREG
 ***/
-static const uint8_t vs23_read_regs[] PROGMEM = {
-  0x01, 0x9f, 0x84, 0x86, 0xb7, 0x53
-};
 num_t BASIC_INT Basic::nvreg() {
 #ifdef USE_VS23
-  int32_t a = getparam();
-  bool good = false;
-  for (uint32_t i = 0; i < sizeof(vs23_read_regs); ++i) {
-    if (pgm_read_byte(&vs23_read_regs[i]) == a) {
-      good = true;
-      break;
-    }
+  uint32_t opcode = getparam();
+  switch(opcode) {
+    case 0x05:
+    case 0x84:
+    case 0x86:
+    case 0xB7: return SpiRamReadRegister8(opcode);
+    case 0x53:
+    case 0x9F: return SpiRamReadRegister(opcode);
+    default:   err = ERR_VALUE; return 0;
   }
-  if (!good) {
-    err = ERR_VALUE;
-    return 0;
-  } else
-    return SpiRamReadRegister(a);
 #else
   err = ERR_NOT_SUPPORTED;
   return 0;

--- a/ttbasic/basic_video.cpp
+++ b/ttbasic/basic_video.cpp
@@ -500,12 +500,12 @@ Read a location in video memory.
 ***/
 num_t BASIC_FP Basic::nvpeek() {
 #ifdef USE_VS23
-  num_t value = getparam();
-  if (value < 0 || value > 131071) {
+  num_t addr = getparam();
+  if (addr < 0 || addr > 131071) {
     E_VALUE(0, 131071);
     return 0;
-  } else
-    return SpiRamReadByte(value);
+  }
+  return SpiRamReadByte(addr);
 #else
   err = ERR_NOT_SUPPORTED;
   return 0;
@@ -513,20 +513,26 @@ num_t BASIC_FP Basic::nvpeek() {
 }
 
 /***bc scr VPOKE
-Write one byte of data to video memory.
+Write data to video memory.
 
 WARNING: Incorrect use of this command can configure the video controller to
 produce invalid output, with may cause damage to older CRT displays.
 \usage VPOKE addr, val
 \args
 @addr	video memory address [`0` to `131071`]
-@val	value [`0` to `255`]
+@val	value [0 to 255] or string expression
 \ref VPEEK()
 ***/
 void BASIC_INT Basic::ivpoke() {
 #ifdef USE_VS23
   int32_t addr, value;
   if (getParam(addr, 0, 131071, I_COMMA)) return;
+  if (is_strexp()) {
+    BString str = istrexp();
+    if ((value = str.length()))
+      SpiRamWriteBytes(addr, (uint8_t *)str.c_str(), value);
+    return;
+  }
   if (getParam(value, 0, 255, I_NONE)) return;
   SpiRamWriteByte(addr, value);
 #else

--- a/ttbasic/ntsc.cpp
+++ b/ttbasic/ntsc.cpp
@@ -154,12 +154,12 @@ void SpiRamWriteByte(register uint32_t address, uint8_t data)
 {
 	uint8_t req[5];
 
-	vs23Select();
 	req[0] = 2;
 	req[1] = address >> 16;
 	req[2] = address >> 8;
 	req[3] = address;
 	req[4] = data;
+	vs23Select();
 	SPI.writeBytes(req, 5);
 	vs23Deselect();
 	// if (SpiRamReadByte(address) != data)
@@ -171,11 +171,11 @@ void GROUP(basic_vs23) SpiRamWriteBytes(uint32_t address, uint8_t * data, uint32
 {
 	uint8_t req[4];
 
-	vs23Select();
 	req[0] = 2;
 	req[1] = address >> 16;
 	req[2] = address >> 8;
 	req[3] = address;
+	vs23Select();
 	SPI.writeBytes(req, 4);
 	SPI.writeBytes(data, len);
 	vs23Deselect();
@@ -205,13 +205,13 @@ void SpiRamWriteWord(uint16_t waddress, uint16_t data)
 	uint8_t req[6];
 	uint32_t address = (uint32_t) waddress * 2;
 
-	vs23Select();
 	req[0] = 2;
 	req[1] = address >> 16;
 	req[2] = address >> 8;
 	req[3] = address;
 	req[4] = data >> 8;
 	req[5] = data;
+	vs23Select();
 	SPI.writeBytes(req, 6);
 	vs23Deselect();
 }


### PR DESCRIPTION
- it's now possible to read the video status register (opcode 5, was 1)
- **vreg()** return values are now limited to their respective length
- **save pcx** now works as intended